### PR TITLE
Android: Fixed pointer highlight & messed up zoom.

### DIFF
--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvas.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvas.java
@@ -401,6 +401,18 @@ public class VncCanvas extends GLSurfaceView {
 		super.onPause();
 	}
 
+    @Override
+    protected void onSizeChanged(int w, int h, int oldw, int oldh) {
+        super.onSizeChanged(w, h, oldw, oldh);
+
+        // Synchronize absoluteXPosition & absoluteYPosition with new size.
+        // We use pan() with delta 0 to trigger their re-calculation.
+        //
+        // oldw & oldh will be 0 if we are just now added to activity.
+        if (oldw != 0 || oldh != 0) {
+            pan(0, 0);
+        }
+    }
 
 
 	/*


### PR DESCRIPTION
This PR fixes issues related to mouse pointer being out of sync after rotation / resize. Zoom is also fixed as both of these were caused by same bug.

Root cause was `absoluteXPosition` & `absoluteYPosition` retaining their old values after rotation/resize.