### PR TITLE
Android: Fixes menu in VncCanvasActivity

### DIFF
--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
@@ -54,6 +54,7 @@ import android.view.VelocityTracker;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.widget.PopupMenu;
 import android.widget.Toast;
 import android.view.inputmethod.InputMethodManager;
 import android.content.Context;
@@ -61,7 +62,7 @@ import android.content.Context;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 
 @SuppressWarnings("deprecation")
-public class VncCanvasActivity extends Activity {
+public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemClickListener {
 
 
 	public class MightyInputHandler extends AbstractGestureInputHandler {
@@ -530,6 +531,7 @@ public class VncCanvasActivity extends Activity {
 	ViewGroup mousebuttons;
 	TouchPointView touchpoints;
 	Toast notificationToast;
+	PopupMenu popupMenu;
 
 	private SharedPreferences prefs;
 
@@ -573,12 +575,17 @@ public class VncCanvasActivity extends Activity {
 		 * setup floating action button
 		 */
 		FloatingActionButton fab = findViewById(R.id.fab);
-		fab.setOnClickListener(new View.OnClickListener() {
-			@Override
-			public void onClick(View view) {
-			    Log.d(TAG, "FAB onClick");
-				openOptionsMenu();
+		fab.setOnClickListener(view -> {
+			Log.d(TAG, "FAB onClick");
+
+			if (popupMenu == null) {
+				popupMenu = new PopupMenu(this, view);
+				popupMenu.inflate(R.menu.vnccanvasactivitymenu);
+				popupMenu.setOnMenuItemClickListener(this);
 			}
+
+			preparePopupMenu(popupMenu);
+			popupMenu.show();
 		});
 
 
@@ -854,19 +861,10 @@ public class VncCanvasActivity extends Activity {
 
 	}
 
-	@SuppressLint("NewApi")
-	@Override
-	public boolean onCreateOptionsMenu(Menu menu) {
-		getMenuInflater().inflate(R.menu.vnccanvasactivitymenu, menu);
-
-		return true;
-	}
-
-
-	@Override
-	public boolean onPrepareOptionsMenu(Menu menu) {
+	private void preparePopupMenu(PopupMenu popupMenu) {
 		try {
-			if(touchpoints.getVisibility() == View.VISIBLE) {
+			Menu menu = popupMenu.getMenu();
+			if (touchpoints.getVisibility() == View.VISIBLE) {
 				menu.findItem(R.id.itemColorMode).setVisible(false);
 				menu.findItem(R.id.itemTogglePointerHighlight).setVisible(false);
 			}
@@ -876,12 +874,10 @@ public class VncCanvasActivity extends Activity {
 			}}
 		catch(NullPointerException e) { // when menu is initially created
 		}
-
-		return super.onPrepareOptionsMenu(menu);
 	}
 
 	@Override
-	public boolean onOptionsItemSelected(MenuItem item) {
+	public boolean onMenuItemClick(MenuItem item) {
 
 		SharedPreferences.Editor ed = prefs.edit();
 

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
@@ -531,7 +531,7 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 	ViewGroup mousebuttons;
 	TouchPointView touchpoints;
 	Toast notificationToast;
-	PopupMenu popupMenu;
+	PopupMenu fabMenu;
 
 	private SharedPreferences prefs;
 
@@ -577,12 +577,12 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 		FloatingActionButton fab = findViewById(R.id.fab);
 		fab.setOnClickListener(view -> {
 			Log.d(TAG, "FAB onClick");
-			preparePopupMenu(popupMenu);
-			popupMenu.show();
+			prepareFabMenu(fabMenu);
+			fabMenu.show();
 		});
-		popupMenu = new PopupMenu(this, fab);
-		popupMenu.inflate(R.menu.vnccanvasactivitymenu);
-		popupMenu.setOnMenuItemClickListener(this);
+		fabMenu = new PopupMenu(this, fab);
+		fabMenu.inflate(R.menu.vnccanvasactivitymenu);
+		fabMenu.setOnMenuItemClickListener(this);
 
 
 		/*
@@ -857,7 +857,10 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 
 	}
 
-	private void preparePopupMenu(PopupMenu popupMenu) {
+	/**
+	 * Prepare FAB popup menu.
+	 */
+	private void prepareFabMenu(PopupMenu popupMenu) {
 		Menu menu = popupMenu.getMenu();
 		if (touchpoints.getVisibility() == View.VISIBLE) {
 			menu.findItem(R.id.itemColorMode).setVisible(false);
@@ -1005,7 +1008,7 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 		if(Utils.DEBUG()) Log.d(TAG, "Input: key down: " + evt.toString());
 
 		if (keyCode == KeyEvent.KEYCODE_MENU) {
-			popupMenu.show();
+			fabMenu.show();
 			return true;
 		}
 

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
@@ -572,21 +572,17 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 		inputHandler.init();
 
 		/*
-		 * setup floating action button
+		 * Setup floating action button & associated menu
 		 */
 		FloatingActionButton fab = findViewById(R.id.fab);
 		fab.setOnClickListener(view -> {
 			Log.d(TAG, "FAB onClick");
-
-			if (popupMenu == null) {
-				popupMenu = new PopupMenu(this, view);
-				popupMenu.inflate(R.menu.vnccanvasactivitymenu);
-				popupMenu.setOnMenuItemClickListener(this);
-			}
-
 			preparePopupMenu(popupMenu);
 			popupMenu.show();
 		});
+		popupMenu = new PopupMenu(this, fab);
+		popupMenu.inflate(R.menu.vnccanvasactivitymenu);
+		popupMenu.setOnMenuItemClickListener(this);
 
 
 		/*
@@ -1008,8 +1004,10 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 	public boolean onKeyDown(int keyCode, KeyEvent evt) {
 		if(Utils.DEBUG()) Log.d(TAG, "Input: key down: " + evt.toString());
 
-		if (keyCode == KeyEvent.KEYCODE_MENU)
-			return super.onKeyDown(keyCode, evt);
+		if (keyCode == KeyEvent.KEYCODE_MENU) {
+			popupMenu.show();
+			return true;
+		}
 
 		if(keyCode == KeyEvent.KEYCODE_BACK) {
 

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
@@ -862,17 +862,13 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 	}
 
 	private void preparePopupMenu(PopupMenu popupMenu) {
-		try {
-			Menu menu = popupMenu.getMenu();
-			if (touchpoints.getVisibility() == View.VISIBLE) {
-				menu.findItem(R.id.itemColorMode).setVisible(false);
-				menu.findItem(R.id.itemTogglePointerHighlight).setVisible(false);
-			}
-			else {
-				menu.findItem(R.id.itemColorMode).setVisible(true);
-				menu.findItem(R.id.itemTogglePointerHighlight).setVisible(true);
-			}}
-		catch(NullPointerException e) { // when menu is initially created
+		Menu menu = popupMenu.getMenu();
+		if (touchpoints.getVisibility() == View.VISIBLE) {
+			menu.findItem(R.id.itemColorMode).setVisible(false);
+			menu.findItem(R.id.itemTogglePointerHighlight).setVisible(false);
+		} else {
+			menu.findItem(R.id.itemColorMode).setVisible(true);
+			menu.findItem(R.id.itemTogglePointerHighlight).setVisible(true);
 		}
 	}
 
@@ -902,8 +898,6 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 				vncCanvas.setVisibility(View.GONE);
 				touchpoints.setVisibility(View.VISIBLE);
 			}
-			// trigger onCreateOptions
-			invalidateMyOptionsMenu();
 			return true;
 
 		case R.id.itemToggleMouseButtons:
@@ -1245,13 +1239,12 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 						| View.SYSTEM_UI_FLAG_FULLSCREEN);
 	}
 
-	private void invalidateMyOptionsMenu() {
-		invalidateOptionsMenu();
-	}
-
 	/*
 	 * Overwrite buggy implementation on Samsung devices where menu would not open when triggered
 	 * from FAB. Stolen from https://github.com/EasyRPG/Player/pull/567 :-)
+	 *
+	 * TODO: This is not used any more and should be removed. 
+	 * TODO: Need to verify that PopupMenu is not affected by similar issue.
 	 */
 	@Override
 	public void openOptionsMenu() {

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -12,9 +12,6 @@
         <item name="android:windowBackground">@color/ui_background</item>
         <item name="android:textColorPrimary">@color/ui_text</item>
 
-        <!-- https://stackoverflow.com/questions/31777167/android-options-menu-is-transparent -->
-        <item name="android:panelBackground">@color/ui_background</item>
-
         <!-- make all buttons coloured -->
         <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Colored</item>
     </style>


### PR DESCRIPTION
Currently menu does not work correctly with rotation. It does not track the FAB for positioning.

This PR replaces options menu with a PopupMenu which is tied directly to FAB. 
- Now menu is show correctly in all orientations.
- Looks nicer & animation slides down from FAB's position.
- Workarounds for existing menu are no longer required.

