### PR TITLE
Android: Allow rotation of canvas activity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
 				<category android:name="android.intent.category.LAUNCHER" />
 			</intent-filter>
 		</activity>
-		<activity android:screenOrientation="landscape" android:configChanges="orientation|keyboardHidden" android:name="VncCanvasActivity">
+		<activity  android:configChanges="orientation|keyboardHidden|screenSize|screenLayout" android:name="VncCanvasActivity">
 			<intent-filter>
 				<action android:name="android.intent.action.VIEW" />
 			</intent-filter>


### PR DESCRIPTION
This PR enables rotations of `VncCanvasActivity` with custom configuration handling.

In addition to `orientation` we also needs to handle `screenSize` & `screenLayout` to avoid restart.
 Reference: https://developer.android.com/guide/topics/manifest/activity-element.html#config


Depends on: #47  , #48 
 
We can handle the case of activity being killed in background  after #46.