### PR TITLE
Android: Refactor VNCConn

### DIFF
--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/AbstractBitmapData.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/AbstractBitmapData.java
@@ -28,12 +28,10 @@ abstract class AbstractBitmapData {
 	int bitmapPixels[];
 	Canvas memGraphics;
 	boolean waitingForInput;
-	VncCanvas vncCanvas;
 
-	AbstractBitmapData( RfbProto p, VncCanvas c)
+	AbstractBitmapData( RfbProto p)
 	{
 		rfb=p;
-		vncCanvas = c;
 		framebufferwidth=rfb.framebufferWidth;
 		framebufferheight=rfb.framebufferHeight;
 	}
@@ -42,24 +40,15 @@ abstract class AbstractBitmapData {
 	{
 		waitingForInput=false;
 	}
-	
-	final void invalidateMousePosition()
-	{
-		if (vncCanvas.vncConn.getConnSettings().getUseLocalCursor())
-			// OpenGL always draws the full framebuffer, request a redraw from GL thread
-			vncCanvas.requestRender();
-	}
-	
+
 	/**
 	 * 
 	 * @return The smallest scale supported by the implementation; the scale at which
 	 * the bitmap would be smaller than the screen
 	 */
-	float getMinimumScale()
+	float getMinimumScale(int displayWidth, int displayHeight)
 	{
 		double scale = 0.75;
-		int displayWidth = vncCanvas.getWidth();
-		int displayHeight = vncCanvas.getHeight();
 		for (; scale >= 0; scale -= 0.25)
 		{
 			if (scale * bitmapwidth < displayWidth || scale * bitmapheight < displayHeight)
@@ -129,8 +118,10 @@ abstract class AbstractBitmapData {
 	 * not change the bitmap data or send a network request until syncScroll is called
 	 * @param newx Position of left edge of visible part in full-frame coordinates
 	 * @param newy Position of top edge of visible part in full-frame coordinates
+	 * @param visibleWidth Width of visible canvas
+	 * @param visibleHeight Height of visible canvas
 	 */
-	abstract void scrollChanged( int newx, int newy);
+	abstract void scrollChanged( int newx, int newy, int visibleWidth, int visibleHeight );
 	
 	/**
 	 * Sync scroll -- called from network thread; copies scroll changes from UI to network state

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/FullBufferBitmapData.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/FullBufferBitmapData.java
@@ -26,10 +26,9 @@ class FullBufferBitmapData extends AbstractBitmapData {
 	
 	/**
 	 * @param p
-	 * @param c
 	 */
-	public FullBufferBitmapData(RfbProto p, VncCanvas c, int capacity) {
-		super(p, c);
+	public FullBufferBitmapData(RfbProto p) {
+		super(p);
 		framebufferwidth=rfb.framebufferWidth;
 		framebufferheight=rfb.framebufferHeight;
 		bitmapwidth= Utils.nextPow2(framebufferwidth);
@@ -88,7 +87,7 @@ class FullBufferBitmapData extends AbstractBitmapData {
 	 * @see com.coboltforge.dontmind.multivnc.AbstractBitmapData#scrollChanged(int, int)
 	 */
 	@Override
-	void scrollChanged(int newx, int newy) {
+	void scrollChanged(int newx, int newy, int visibleWidth, int visibleHeight ) {
 		xoffset = newx;
 		yoffset = newy;
 	}

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/LargeBitmapData.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/LargeBitmapData.java
@@ -57,14 +57,12 @@ class LargeBitmapData extends AbstractBitmapData {
 	/**
 	 * 
 	 * @param p Protocol implementation
-	 * @param c View that will display screen
-	 * @param displayWidth
-	 * @param displayHeight
+	 * @param conn Vnc connection
 	 * @param capacity Max process heap size in bytes
 	 */
-	LargeBitmapData(RfbProto p, VncCanvas c, VNCConn conn, int capacity)
+	LargeBitmapData(RfbProto p, VNCConn conn, int capacity)
 	{
-		super(p,c);
+		super(p);
 		double scaleMultiplier = Math.sqrt((double)(capacity * 1024 * 1024) / (double)(CAPACITY_MULTIPLIER * framebufferwidth * framebufferheight));
 		if (scaleMultiplier > 1)
 			scaleMultiplier = 1;
@@ -113,12 +111,10 @@ class LargeBitmapData extends AbstractBitmapData {
 	 * @see com.coboltforge.dontmind.multivnc.AbstractBitmapData#scrollChanged(int, int)
 	 */
 	@Override
-	synchronized void scrollChanged(int newx, int newy) {
+	synchronized void scrollChanged(int newx, int newy, int visibleWidth, int visibleHeight ) {
 		//android.util.Log.i("LBM","scroll "+newx+" "+newy);
 		int newScrolledToX = scrolledToX;
 		int newScrolledToY = scrolledToY;
-		int visibleWidth = vncCanvas.getVisibleWidth();
-		int visibleHeight = vncCanvas.getVisibleHeight();
 		if (newx - xoffset < 0 )
 		{
 			newScrolledToX = newx + visibleWidth / 2 - bitmapwidth / 2;

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/Utils.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/Utils.java
@@ -148,7 +148,7 @@ public class Utils {
 	}
 
 
-	public static NetworkInterface getActiveNetworkInterface(Context c) {
+	public static NetworkInterface getActiveNetworkInterface() {
 		try {
 			for (Enumeration<NetworkInterface> en = NetworkInterface.getNetworkInterfaces(); en.hasMoreElements();) {
 				NetworkInterface intf = en.nextElement();

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VNCConn.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VNCConn.java
@@ -257,7 +257,7 @@ public class VNCConn {
 				Inet6Address in6 = Inet6Address.getByAddress(
 						address.getHostName(),
 						address.getAddress(),
-						Utils.getActiveNetworkInterface(canvas.getContext()));
+						Utils.getActiveNetworkInterface());
 
 				connSettings.setAddress(in6.getHostAddress());
 				Log.i(TAG, "Using IPv6");

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvas.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvas.java
@@ -837,37 +837,6 @@ public class VncCanvas extends GLSurfaceView {
 		return yoffset;
 	}
 
-
-	public void getCredsFromUser(final ConnectionBean c, boolean isUserNameNeeded) {
-		// this method is probably called from the vnc thread
-		post(new Runnable() {
-			@Override
-			public void run() {
-
-				LayoutInflater layoutinflater = LayoutInflater.from(activity);
-				View credentialsDialog = layoutinflater.inflate(R.layout.credentials_dialog, null);
-				if(!isUserNameNeeded)
-					credentialsDialog.findViewById(R.id.username_row).setVisibility(GONE);
-
-				new AlertDialog.Builder(getContext())
-						.setTitle(getContext().getString(R.string.credentials_needed_title))
-						.setView(credentialsDialog)
-						.setCancelable(false)
-						.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-							public void onClick(DialogInterface dialog, int whichButton) {
-								if(isUserNameNeeded)
-									c.setUserName(((EditText)credentialsDialog.findViewById(R.id.userName)).getText().toString());
-								c.setPassword(((EditText)credentialsDialog.findViewById(R.id.password)).getText().toString());
-								synchronized (vncConn) {
-									vncConn.notify();
-								}
-							}
-						}).show();
-			}
-		});
-
-	}
-
 	public ScaleType getScaleType() {
 		// TODO Auto-generated method stub
 		return null;

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvas.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvas.java
@@ -564,7 +564,11 @@ public class VncCanvas extends GLSurfaceView {
 	protected void onScrollChanged(int l, int t, int oldl, int oldt) {
 		super.onScrollChanged(l, t, oldl, oldt);
 		try {
-			vncConn.getFramebuffer().scrollChanged(absoluteXPosition, absoluteYPosition);
+			vncConn.getFramebuffer().scrollChanged(
+					absoluteXPosition,
+					absoluteYPosition,
+					getVisibleWidth(),
+					getVisibleHeight());
 			mouseFollowPan();
 		}
 		catch(NullPointerException e) {
@@ -674,7 +678,7 @@ public class VncCanvas extends GLSurfaceView {
 	 * Convert a motion event to a format suitable for sending over the wire
 	 * @param evt motion event; x and y must already have been converted from screen coordinates
 	 * to remote frame buffer coordinates.
-	 * @param downEvent True if "mouse button" (touch or trackball button) is down when this happens
+	 * @param mouseIsDown True if "mouse button" (touch or trackball button) is down when this happens
 	 * @param useRightButton If true, event is interpreted as happening with right mouse button
 	 * @return true if event was actually sent
 	 */

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ZoomScaling.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ZoomScaling.java
@@ -172,7 +172,12 @@ class ZoomScaling extends AbstractScaling {
 		try {
 			super.setScaleTypeForActivity(activity);
 			scaling = (float)1.0;
-			minimumScale = activity.vncCanvas.vncConn.getFramebuffer().getMinimumScale();
+			int canvasWidth = activity.vncCanvas.getWidth();
+			int canvasHeight = activity.vncCanvas.getHeight();
+
+			minimumScale = activity.vncCanvas.vncConn.getFramebuffer()
+					.getMinimumScale(canvasWidth, canvasHeight);
+
 			canvasXOffset = -activity.vncCanvas.getCenteredXOffset();
 			canvasYOffset = -activity.vncCanvas.getCenteredYOffset();
 			resetMatrix();


### PR DESCRIPTION
This PR decouples VNCConn and frame-buffer/bitmap-data from `VncCanvas` & `VncCanvasActivity`.

Summary:
- `VNCConn` exposes `ObserverInterface`.
- `VncCanvasActivity` implements `ObserverInterface`.
- `AbstractBitmapData` does not keep a reference to `VncCanvas`. Instead, required values are passed as method arguments.

This would allow us to keep `VNCConn` alive insde ViewModel as per #46. (Even if we don't want to go in that direction, this PR allow us to move UI Code out of `VNCConn`).