### PR TITLE
Android: Fix Spinner style

### DIFF
--- a/android/app/src/main/res/layout/new_conn_element.xml
+++ b/android/app/src/main/res/layout/new_conn_element.xml
@@ -59,8 +59,7 @@
 
             <Spinner
                 android:id="@+id/spinnerColorMode"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:prompt="@string/colormode_caption" />
         </TableRow>
 


### PR DESCRIPTION
Ensure that Spinner does not overflow and hide arrow on some devices.

It is also consistent with other widgets in `new_conn_element.xml`. All of them have their `android:layout_weight` attribute set to 1.

---------------
**Android Emulator**
*Before*
![image](https://user-images.githubusercontent.com/27951674/75268499-94163280-581d-11ea-9fe3-4a4761ccd643.png)
*Now*
![image](https://user-images.githubusercontent.com/27951674/75268532-a001f480-581d-11ea-8b2c-f545b318cd6b.png)

---
**Redmi Note 3**
*Before*
![image](https://user-images.githubusercontent.com/27951674/75268603-b445f180-581d-11ea-8db7-cbd4fd08e8e4.png)
*Now*
![image](https://user-images.githubusercontent.com/27951674/75268621-bb6cff80-581d-11ea-96e6-a0d8621a5e71.png)


----
I would also like to add small top&bottom padding to Spinner so that its height is similar to other widgets. I can submit a PR if you are okay with it?


