### PR TITLE
Android: Fix gravity issues with TextViews for new connection.

### DIFF
--- a/android/app/src/main/res/layout/new_conn_element.xml
+++ b/android/app/src/main/res/layout/new_conn_element.xml
@@ -17,7 +17,7 @@
         <TableRow>
 
             <TextView
-                android:gravity="right|center_vertical"
+                android:layout_gravity="right|center_vertical"
                 android:paddingRight="10dip"
                 android:text="@string/address_caption"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -34,7 +34,7 @@
         <TableRow>
 
             <TextView
-                android:gravity="right|center_vertical"
+                android:layout_gravity="right|center_vertical"
                 android:paddingRight="10dip"
                 android:text="@string/port_caption"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -52,7 +52,7 @@
         <TableRow>
 
             <TextView
-                android:gravity="right|center_vertical"
+                android:layout_gravity="right|center_vertical"
                 android:paddingRight="10dip"
                 android:text="@string/colormode_caption"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -66,7 +66,7 @@
         <TableRow>
 
             <TextView
-                android:gravity="right|center_vertical"
+                android:layout_gravity="right|center_vertical"
                 android:paddingRight="10dip"
                 android:text="@string/username_caption"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -83,7 +83,7 @@
         <TableRow>
 
             <TextView
-                android:gravity="right|center_vertical"
+                android:layout_gravity="right|center_vertical"
                 android:paddingRight="10dip"
                 android:text="@string/password_caption"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
@@ -114,7 +114,7 @@
         <TableRow>
 
             <TextView
-                android:gravity="right|center_vertical"
+                android:layout_gravity="right|center_vertical"
                 android:paddingRight="10dip"
                 android:text="@string/repeater_caption"
                 android:textAppearance="?android:attr/textAppearanceMedium" />


### PR DESCRIPTION
Currently `gravity` attribute is used for these `TextView`s but it has no effect on the alignment of these views inside parent container.

Due to this, 'Password' is not aligned to vertical center (I am surprised that others don't show the same issue):

![image](https://user-images.githubusercontent.com/27951674/75367529-7cef4780-58e6-11ea-89c0-ec611e3bc349.png)

We should use `layout_gravity` to change the alignment inside parent container. After this PR:

![image](https://user-images.githubusercontent.com/27951674/75367859-ee2efa80-58e6-11ea-8174-fce12c4747bf.png)




