### PR TITLE
Android: Zoom controls cleanup

### DIFF
--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvasActivity.java
@@ -1199,26 +1199,17 @@ public class VncCanvasActivity extends Activity implements PopupMenu.OnMenuItemC
 	}
 
 
-	long hideZoomAfterMs;
 	static final long ZOOM_HIDE_DELAY_MS = 2500;
-	HideZoomRunnable hideZoomInstance = new HideZoomRunnable();
+	Runnable hideZoomInstance = () -> zoomer.hide();
 
 	private void showZoomer(boolean force) {
 		if (force || zoomer.getVisibility() != View.VISIBLE) {
 			zoomer.show();
-			hideZoomAfterMs = SystemClock.uptimeMillis() + ZOOM_HIDE_DELAY_MS;
-			vncCanvas.handler
-					.postAtTime(hideZoomInstance, hideZoomAfterMs + 10);
-		}
-	}
 
-	private class HideZoomRunnable implements Runnable {
-		public void run() {
-			if (SystemClock.uptimeMillis() >= hideZoomAfterMs) {
-				zoomer.hide();
-			}
+			//Schedule hiding of zoom controls.
+			vncCanvas.handler.removeCallbacks(hideZoomInstance);
+			vncCanvas.handler.postDelayed(hideZoomInstance, ZOOM_HIDE_DELAY_MS);
 		}
-
 	}
 
 	public void showScaleToast()

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ZoomControls.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ZoomControls.java
@@ -82,16 +82,7 @@ public class ZoomControls extends LinearLayout {
     public void setOnZoomKeyboardClickListener(OnClickListener listener) {
     	mZoomKeyboard.setOnClickListener(listener);
     }
-    
-    /*
-     * Sets how fast you get zoom events when the user holds down the
-     * zoom in/out buttons.
-     */
-    public void setZoomSpeed(long speed) {
-        mZoomIn.setZoomSpeed(speed);
-        mZoomOut.setZoomSpeed(speed);
-    }
-    
+
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ZoomControls.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ZoomControls.java
@@ -40,8 +40,6 @@ import android.graphics.PorterDuff;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
-import android.view.View;
-import android.view.animation.AlphaAnimation;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.ZoomButton;
@@ -104,19 +102,17 @@ public class ZoomControls extends LinearLayout {
     }
     
     public void show() {
-        fade(View.VISIBLE, 0.0f, 1.0f);
+        setVisibility(VISIBLE);
+
+        //Workaround for buggy GLSurfaceView.
+        //See https://stackoverflow.com/questions/11236336/setvisibilityview-visible-doesnt-always-work-ideas
+        requestLayout();
     }
     
     public void hide() {
-        fade(View.GONE, 1.0f, 0.0f);
+        setVisibility(INVISIBLE);
     }
-    
-    private void fade(int visibility, float startAlpha, float endAlpha) {
-        AlphaAnimation anim = new AlphaAnimation(startAlpha, endAlpha);
-        anim.setDuration(500);
-        startAnimation(anim);
-        setVisibility(visibility);
-    }
+
     
     public void setIsZoomInEnabled(boolean isEnabled) {
         mZoomIn.setEnabled(isEnabled);

--- a/android/app/src/main/res/layout/canvas.xml
+++ b/android/app/src/main/res/layout/canvas.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
+	android:animateLayoutChanges="true"
     >
 
 	<com.coboltforge.dontmind.multivnc.VncCanvas
@@ -80,4 +81,4 @@
 	 </LinearLayout>
 
 
-</merge>
+</FrameLayout>


### PR DESCRIPTION
This PR replaces custom animation logic for `ZoomControls` with in-built layout animations provided by Android. It also simplifies the show/hide logic for these controls.

Primary motivation is to enable in-built animations. These can be used by other controls like scale indicator `TextView` mentioned in #70 .
