### PR TITLE
Android: Enable SIMD support (mainly used by libjpeg-turbo)

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -2,6 +2,7 @@
 bin/
 gen/
 build/
+.cxx/
 
 # Gradle
 .gradle/

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -3,6 +3,13 @@ cmake_minimum_required(VERSION 3.4.1)
 
 project (MultiVNC C ASM) # defaults to C, the ASM is needed for LibreSSL
 
+# Requred to enable SIMD support
+if (CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} --target=aarch64-linux-android${ANDROID_VERSION}")
+elseif (CMAKE_ANDROID_ARCH_ABI MATCHES "^armeabi.*")  # armeabi-v7a || armeabi-v6 || armeabi
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} --target=arm-linux-androideabi${ANDROID_VERSION}")
+endif ()
+
 # build libJPEG
 set(BUILD_SHARED_LIBS OFF)
 set(libjpeg_src_DIR ../../../../../libjpeg-turbo)


### PR DESCRIPTION
Enables SIMD support.

libjpeg-turbo depends heavily on SIMD and warns about missing support during build.

Related: https://github.com/libjpeg-turbo/libjpeg-turbo/blob/master/BUILDING.md#building-libjpeg-turbo-for-android


This improves the performance noticeably.


Also added `.cxx` to .gitignore
