### PR TITLE
Android: Fix last key-combo not being remembered.

### DIFF
--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/MetaKeyDialog.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/MetaKeyDialog.java
@@ -230,7 +230,7 @@ class MetaKeyDialog extends Dialog {
 		if (index < 0)
 		{
 			int insertionPoint = -(index + 1);
-			_database.getMetaKeyDao().insert(_currentKeyBean);
+			_currentKeyBean.id = _database.getMetaKeyDao().insert(_currentKeyBean);
 			_keysInList.add(insertionPoint,_currentKeyBean);
 			_connection.lastMetaKeyId = _currentKeyBean.id;
 		}


### PR DESCRIPTION
This was a regression caused by migration to Room.

Old library would update the `id` of `_currentKeyBean` automatically inside its `Gen_insert` method but Room does't do that so the `id` of `_currentKeyBean` was always 0. So `_connection.lastMetaKeyId` would always be 0 instead of pointing to correct id.
