### PR TITLE
Android: Use correct CMake variables for SIMD target

### DIFF
--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -3,11 +3,11 @@ cmake_minimum_required(VERSION 3.4.1)
 
 project (MultiVNC C ASM) # defaults to C, the ASM is needed for LibreSSL
 
-# Requred to enable SIMD support
-if (CMAKE_ANDROID_ARCH_ABI STREQUAL "arm64-v8a")
-    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} --target=aarch64-linux-android${ANDROID_VERSION}")
-elseif (CMAKE_ANDROID_ARCH_ABI MATCHES "^armeabi.*")  # armeabi-v7a || armeabi-v6 || armeabi
-    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} --target=arm-linux-androideabi${ANDROID_VERSION}")
+# Requred to enable SIMD support on ARM
+if (CMAKE_ANDROID_ARCH STREQUAL "arm64")
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} --target=aarch64-linux-android${ANDROID_NATIVE_API_LEVEL}")
+elseif (CMAKE_ANDROID_ARCH STREQUAL "arm")
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} --target=arm-linux-androideabi${ANDROID_NATIVE_API_LEVEL}")
 endif ()
 
 # build libJPEG


### PR DESCRIPTION
- `ANDROID_VERSION` is incorrect. We have to use `ANDROID_NATIVE_API_LEVEL` to specify the API level.
  Ref: https://developer.android.com/ndk/guides/cmake#android_native_api_level

- Instead of `CMAKE_ANDROID_ARCH_ABI` we can use `CMAKE_ANDROID_ARCH` to simplify the test for 32bit/64bit platform.
