### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,3 @@ deploy:
   project: build/package
   on:
     condition: $TRAVIS_OS_NAME = linux
-    
-cache:
-  directories:
-  - $HOME/.gradle/caches/
-  - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,8 @@ deploy:
   project: build/package
   on:
     condition: $TRAVIS_OS_NAME = linux
+    
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
     sudo apt-get install libwxgtk3.0-dev libgtk2.0-dev libjpeg62-dev libgcrypt20-dev liblzo2-dev
     CMAKE_URL="http://www.cmake.org/files/v3.13/cmake-3.13.0-Linux-x86_64.tar.gz"
-    mkdir -p ${TRAVIS_BUILD_DIR}/deps/cmake && travis_retry wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${TRAVIS_BUILD_DIR}/deps/cmake
+    mkdir -p ${TRAVIS_BUILD_DIR}/deps/cmake && wget --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C ${TRAVIS_BUILD_DIR}/deps/cmake
     export PATH=${TRAVIS_BUILD_DIR}/deps/cmake/bin:${PATH}
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install wxmac; brew reinstall libffi; fi


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
