### PR TITLE
Android: Add support for night mode (dark theme)

### DIFF
--- a/android/app/src/main/res/layout/about.xml
+++ b/android/app/src/main/res/layout/about.xml
@@ -47,6 +47,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="20dip"
                 android:text="@string/pleaserate"
+				android:textColor="?android:textColorSecondary"
                 android:drawableTop="@drawable/ic_heart"
                 android:background="@android:color/transparent"
                 />

--- a/android/app/src/main/res/values/colours.xml
+++ b/android/app/src/main/res/values/colours.xml
@@ -10,9 +10,4 @@
     // specify colours here to also work on sub-21 API. those get used in layouts *and* styles
     <color name="ui_primary">@color/multivnc_icon_green</color>
     <color name="ui_primary_dark">@color/multivnc_icon_green_dark</color>
-    <color name="ui_accent">@color/ui_primary</color>
-    <color name="ui_text">@android:color/black</color>
-    <color name="ui_background">@android:color/white</color>
-
-
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
 
         <!-- app branding color for the app bar -->
         <item name="colorPrimary">@color/ui_primary</item>
@@ -9,11 +9,12 @@
         <!-- theme UI controls like checkboxes and text fields -->
         <item name="colorAccent">@color/ui_primary</item>
 
-        <item name="android:windowBackground">@color/ui_background</item>
-        <item name="android:textColorPrimary">@color/ui_text</item>
-
         <!-- make all buttons coloured -->
-        <item name="android:buttonStyle">@style/Widget.AppCompat.Button.Colored</item>
+        <item name="android:buttonStyle">@style/App.Button</item>
+    </style>
+
+    <style name="App.Button" parent="Widget.AppCompat.Button.Colored">
+        <item name="android:textColor">@android:color/white</item>
     </style>
 
 </resources>


### PR DESCRIPTION
This adds basic night mode support. If system is in night mode, we will automatically use dark theme.

Fixes #142 