### PR TITLE
Android: Fix Import/Export

### DIFF
--- a/android/app/proguard-rules.txt
+++ b/android/app/proguard-rules.txt
@@ -2,4 +2,25 @@
 -keep class com.antlersoft.** { *; }
 
 
+##########################################################################
+# Rules for keeping JSON Serialization code
+# Ref: https://github.com/Kotlin/kotlinx.serialization#android
+##########################################################################
+
+-keepattributes *Annotation*, InnerClasses
+
+-keepclassmembers class kotlinx.serialization.json.** {
+    *** Companion;
+}
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+-keep,includedescriptorclasses class com.coboltforge.dontmind.multivnc.**$$serializer { *; }
+-keepclassmembers class com.coboltforge.dontmind.multivnc.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.coboltforge.dontmind.multivnc.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
 

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ImportExportDialog.kt
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ImportExportDialog.kt
@@ -64,9 +64,7 @@ class ImportExportDialog : AppCompatDialogFragment() {
                         // import
                         val intent = Intent(Intent.ACTION_OPEN_DOCUMENT)
                         intent.addCategory(Intent.CATEGORY_OPENABLE)
-                        val mimeTypes = arrayOf("text/xml", "application/xml", "application/json")
                         intent.type = "*/*"
-                        intent.putExtra(Intent.EXTRA_MIME_TYPES, mimeTypes)
                         startActivityForResult(intent, REQUEST_CODE_READ_FILE)
                     }
                     1 -> {


### PR DESCRIPTION
This PR fixes two issues with Import/Export:

1. Proguard rules for keeping the JSON serialization code were missing. Without them R8 will strip the serialization code in Release build, breaking Import/Export. This was my fault.
2. Current MIME types for import file doesn't allow users to select any file (not even Json/XML) with standard file picker. Moreover some apps (e.g. CX File Explorer) ignore MIME  types and already allow selecting any file. 