### PR TITLE
Android: Handle middle mouse button

### DIFF
--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/PointerInputHandler.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/PointerInputHandler.java
@@ -348,6 +348,8 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
 
             if (isSPen || Build.VERSION.SDK_INT < 23)
                 vncCanvasActivity.vncCanvas.processPointerEvent(e, true, isSPen || isRightButton);
+            else if (e.getActionMasked() == MotionEvent.ACTION_MOVE)
+                vncCanvasActivity.vncCanvas.processMouseEvent(0, true, (int) e.getX(), (int) e.getY());
 
             return true;
         }

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvas.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VncCanvas.java
@@ -640,7 +640,7 @@ public class VncCanvas extends GLSurfaceView {
 	 * Convert a motion event to a format suitable for sending over the wire
 	 * @param evt motion event; x and y must already have been converted from screen coordinates
 	 * to remote frame buffer coordinates.
-	 * @param downEvent True if "mouse button" (touch or trackball button) is down when this happens
+	 * @param mouseIsDown True if "mouse button" (touch or trackball button) is down when this happens
 	 * @param useRightButton If true, event is interpreted as happening with right mouse button
 	 * @return true if event was actually sent
 	 */
@@ -676,6 +676,29 @@ public class VncCanvas extends GLSurfaceView {
 		}
 		catch(NullPointerException e) {
 			return false;
+		}
+	}
+
+	/**
+	 * Process given mouse event.
+	 *
+	 * @param button Which button is pressed/released (0 for no button)
+	 * @param isDown True if button is down
+	 * @param x,y    Event position in remote frame buffer coordinates.
+	 */
+	public void processMouseEvent(int button, boolean isDown, int x, int y) {
+		try {
+			if (isDown)
+				pointerMask |= button;
+			else
+				pointerMask &= ~button;
+
+			if (overridePointerMask > 0)
+				vncConn.sendPointerEvent(x, y, 0, overridePointerMask);
+			else
+				vncConn.sendPointerEvent(x, y, 0, pointerMask);
+
+		} catch (NullPointerException ignored) {
 		}
 	}
 


### PR DESCRIPTION
Fixes #189 

Middle button is sent to the server, but currently two middle-clicks are sent for single mouse button click. I am about 80% sure this is caused by way GenericMotion events are [translated](https://github.com/bk138/multivnc/blob/bc5f64eeb4a81632bd8dda76b5e2f68b82395dcc/android/app/src/main/java/com/coboltforge/dontmind/multivnc/PointerInputHandler.java#L445-L464) to normal Touch events and processed in `processPointerEvent()`.

My question is why are these events handled this way, instead of directly invoking `sendPointerEvent()` like scroll events?