### PR TITLE
Use constant format string for fprintf calls

### DIFF
--- a/src/VNCConn.cpp
+++ b/src/VNCConn.cpp
@@ -1040,7 +1040,7 @@ void VNCConn::thread_logger(const char *format, ...)
       logfile=fopen(logfile_str.char_str(),"a");    
       
       va_start(args, format);
-      fprintf(logfile, wxString(timebuf).mb_str());
+      fprintf(logfile, "%s", wxString(timebuf).mb_str());
       vfprintf(logfile, format, args);
       va_end(args);
 
@@ -1049,7 +1049,7 @@ void VNCConn::thread_logger(const char *format, ...)
  
   // and stderr
   va_start(args, format);
-  fprintf(stderr, wxString(timebuf).mb_str());
+  fprintf(stderr, "%s", wxString(timebuf).mb_str());
   vfprintf(stderr, format, args);
   va_end(args);
 }


### PR DESCRIPTION
This silences a compiler warning and prevents a fairly serious class of bugs in case the wxString constructor ever changes its behavior to pull data from an external source (highly unlikely, but that's what the compiler is scared of!)