### PR TITLE
fix(macos): bundle SVG toolbar icons into app bundle — fixes launch crash

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,20 @@ if(APPLE)
     set(MACOSX_BUNDLE_ICON_FILE icon.icns)
     set(multivnc_SRCS ${multivnc_SRCS} icon.icns)
     set_source_files_properties(icon.icns PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+
+    # SVG toolbar icons — required at runtime via wxBitmapBundle::FromSVGFile(GetResourcesDir()).
+    # Without these the app crashes immediately on launch (null bitmap in wxToolBarTool::UpdateImages).
+    file(GLOB multivnc_SVG_LIGHT "${CMAKE_CURRENT_SOURCE_DIR}/gui/res/light/*.svg")
+    file(GLOB multivnc_SVG_DARK  "${CMAKE_CURRENT_SOURCE_DIR}/gui/res/dark/*.svg")
+    file(GLOB multivnc_SVG_ROOT  "${CMAKE_CURRENT_SOURCE_DIR}/gui/res/about.svg"
+                                  "${CMAKE_CURRENT_SOURCE_DIR}/gui/res/unicast.svg"
+                                  "${CMAKE_CURRENT_SOURCE_DIR}/gui/res/multicast.svg")
+
+    set_source_files_properties(${multivnc_SVG_LIGHT} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources/light")
+    set_source_files_properties(${multivnc_SVG_DARK}  PROPERTIES MACOSX_PACKAGE_LOCATION "Resources/dark")
+    set_source_files_properties(${multivnc_SVG_ROOT}  PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+
+    list(APPEND multivnc_SRCS ${multivnc_SVG_LIGHT} ${multivnc_SVG_DARK} ${multivnc_SVG_ROOT})
 endif(APPLE)
 
 add_executable(${executable_name} WIN32 MACOSX_BUNDLE ${multivnc_SRCS})


### PR DESCRIPTION
## Problem

On macOS, the app crashes immediately on launch with `SIGABRT` / `EXC_BAD_ACCESS` (null dereference) before the main window appears.

**Crash stack:**
```
FrameMain::FrameMain
  → wxToolBar::DoInsertTool
    → wxToolBarTool::UpdateImages
      → wxBitmap::UseAlpha(bool)  ← null dereference here
```

**Root cause:** `bitmapBundleFromSVGResource()` expands to:
```cpp
wxBitmapBundle::FromSVGFile(GetResourcesDir() + "/light/connect.svg", wxSize(24,24))
```
The upstream `src/CMakeLists.txt` only packages `icon.icns` into `Contents/Resources`. All toolbar SVGs (`light/`, `dark/`, root SVGs) are missing from the app bundle, so `FromSVGFile` returns an invalid `wxBitmapBundle`. When wxWidgets 3.3.x then calls `UseAlpha()` on the null internal object, the process aborts.

## Fix

Added `file(GLOB)` rules in `src/CMakeLists.txt` with `MACOSX_PACKAGE_LOCATION` set to the correct `Resources/light`, `Resources/dark`, and `Resources/` paths so every cmake build produces a complete bundle automatically:

```cmake
file(GLOB multivnc_SVG_LIGHT "${CMAKE_CURRENT_SOURCE_DIR}/gui/res/light/*.svg")
file(GLOB multivnc_SVG_DARK  "${CMAKE_CURRENT_SOURCE_DIR}/gui/res/dark/*.svg")
file(GLOB multivnc_SVG_ROOT  "${CMAKE_CURRENT_SOURCE_DIR}/gui/res/about.svg" ...)

set_source_files_properties(${multivnc_SVG_LIGHT} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources/light")
set_source_files_properties(${multivnc_SVG_DARK}  PROPERTIES MACOSX_PACKAGE_LOCATION "Resources/dark")
set_source_files_properties(${multivnc_SVG_ROOT}  PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")

list(APPEND multivnc_SRCS ${multivnc_SVG_LIGHT} ${multivnc_SVG_DARK} ${multivnc_SVG_ROOT})
```

## Tested on

- macOS 15.7.4 (Sequoia), Apple M3 Pro (ARM64)
- wxWidgets 3.3.2 (Homebrew)
- cmake 3.x, Release build
