### PR TITLE
Android: Jump-desktop style touch mode toggle

### DIFF
--- a/android/app/src/main/cpp/vncconn.c
+++ b/android/app/src/main/cpp/vncconn.c
@@ -762,6 +762,14 @@ JNIEXPORT jboolean JNICALL Java_com_coboltforge_dontmind_multivnc_VNCConn_rfbSet
 }
 #pragma clang diagnostic pop
 
+JNIEXPORT jboolean JNICALL Java_com_coboltforge_dontmind_multivnc_VNCConn_rfbSendFramebufferUpdateRequest(JNIEnv *env, jobject obj, jint x, jint y, jint w, jint h, jboolean incremental) {
+    rfbClient *cl = getRfbClient(env, obj);
+    if(cl)
+        return (jboolean) SendFramebufferUpdateRequest(cl, x, y, w, h, incremental);
+    else
+        return JNI_FALSE;
+}
+
 JNIEXPORT jstring JNICALL Java_com_coboltforge_dontmind_multivnc_VNCConn_rfbGetDesktopName(JNIEnv *env, jobject obj) {
     rfbClient *cl = getRfbClient(env, obj);
     if(cl)

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VNCConn.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/VNCConn.java
@@ -313,13 +313,13 @@ public class VNCConn {
     					sendKeyEvent(ev.key);
     				if(ev.ffur != null)
 						try {
-							// bitmapData.writeFullUpdateRequest(ev.ffur.incremental);
+							rfbSendFramebufferUpdateRequest(0, 0, getFramebufferWidth(), getFramebufferHeight(), ev.ffur.incremental);
 						} catch (Exception e) {
 							e.printStackTrace();
 						}
 					if(ev.fur != null)
 						try {
-							// rfb.writeFramebufferUpdateRequest(ev.fur.x, ev.fur.y, ev.fur.w, ev.fur.h, ev.fur.incremental);
+							rfbSendFramebufferUpdateRequest(ev.fur.x, ev.fur.y, ev.fur.w, ev.fur.h, ev.fur.incremental);
 						} catch (Exception e) {
 							e.printStackTrace();
 						}
@@ -429,6 +429,7 @@ public class VNCConn {
   private native void rfbShutdown();
 	private native boolean rfbProcessServerMessage();
 	private native boolean rfbSetFramebufferUpdatesEnabled(boolean enable);
+	private native boolean rfbSendFramebufferUpdateRequest(int x, int y, int w, int h, boolean incremental);
 	private native String rfbGetDesktopName();
 	private native int rfbGetFramebufferWidth();
 	private native int rfbGetFramebufferHeight();
@@ -693,6 +694,17 @@ public class VNCConn {
 		}
 	}
 
+	public void requestFramebufferUpdate(int x, int y, int w, int h, boolean incremental) {
+		if(!framebufferUpdatesEnabled)
+			return;
+
+		w = Math.max(1, Math.min(w, getFramebufferWidth()));
+		h = Math.max(1, Math.min(h, getFramebufferHeight()));
+		x = Math.max(0, Math.min(x, getFramebufferWidth() - w));
+		y = Math.max(0, Math.min(y, getFramebufferHeight() - h));
+		sendFramebufferUpdateRequest(x, y, w, h, incremental);
+	}
+
 
 	public void setColorModel(COLORMODEL cm) {
 		// Only update if color model changes
@@ -896,4 +908,3 @@ public class VNCConn {
         return false;
     }
 }
-

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/ConnectionEditFragment.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/ConnectionEditFragment.java
@@ -57,6 +57,7 @@ public class ConnectionEditFragment extends Fragment {
     private boolean[] encodingChecksEdit = new boolean[ENCODING_NAMES.length];
     private Spinner compressSpinner;
     private Spinner qualitySpinner;
+    private SwitchMaterial jumpModeSwitch;
     private EditText textUsername;
     private SwitchMaterial sendExtendedKeysSwitch;
     private SwitchMaterial sshSwitch;
@@ -145,6 +146,8 @@ public class ConnectionEditFragment extends Fragment {
         qualitySpinner = (Spinner)view.findViewById(R.id.spinnerQuality);
         ArrayAdapter<QUALITYMODEL> qualitySpinnerAdapter = new ArrayAdapter<QUALITYMODEL>(requireContext(), android.R.layout.simple_spinner_item, QUALITYMODEL.values());
         qualitySpinner.setAdapter(qualitySpinnerAdapter);
+
+        jumpModeSwitch = view.findViewById(R.id.jump_mode_switch);
 
         repeaterText = (TextView)view.findViewById(R.id.textRepeaterId);
 
@@ -265,6 +268,7 @@ public class ConnectionEditFragment extends Fragment {
         conn.colorModel = ((COLORMODEL)colorSpinner.getSelectedItem()).nameString();
         conn.compressModel = ((COMPRESSMODEL)compressSpinner.getSelectedItem()).nameString();
         conn.qualityModel = ((QUALITYMODEL)qualitySpinner.getSelectedItem()).nameString();
+        conn.inputMode = jumpModeSwitch.isChecked() ? InputMode.JUMP.value() : InputMode.DEFAULT.value();
         if (repeaterText.getText().length() > 0)
         {
             conn.repeaterId = repeaterText.getText().toString().trim();
@@ -345,6 +349,8 @@ public class ConnectionEditFragment extends Fragment {
         setSpinnerByEnum(colorSpinner, COLORMODEL.values(), COLORMODEL.valueOf(conn.colorModel));
         setSpinnerByEnum(compressSpinner, COMPRESSMODEL.values(), COMPRESSMODEL.valueOf(conn.compressModel));
         setSpinnerByEnum(qualitySpinner, QUALITYMODEL.values(), QUALITYMODEL.valueOf(conn.qualityModel));
+        jumpModeSwitch.setChecked(InputMode.JUMP == InputMode.fromValue(conn.inputMode));
+        view.findViewById(R.id.input_mode_row).setVisibility(View.VISIBLE);
 
         // if this is a connection that was not bookmarked, stop here
         if (conn.id == 0)

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/GLShape.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/GLShape.java
@@ -58,6 +58,14 @@ public class GLShape {
 
 	// Render the shape
 	public void draw(GL10 gl) {
+		draw(gl, false);
+	}
+
+	public void drawOutline(GL10 gl) {
+		draw(gl, true);
+	}
+
+	private void draw(GL10 gl, boolean outline) {
 		// Disable 2d textures, otherwise shape won't show
 		gl.glDisable(GL10.GL_TEXTURE_2D);
 		// Enable vertex-array and define its buffer
@@ -70,7 +78,7 @@ public class GLShape {
 		
 		if(kind == CIRCLE) {
 			gl.glVertexPointer (2, GL10.GL_FLOAT , 0, vertexBuffer); 
-			gl.glDrawArrays (GL10.GL_TRIANGLE_FAN, 0, circleSegments);
+			gl.glDrawArrays (outline ? GL10.GL_LINE_LOOP : GL10.GL_TRIANGLE_FAN, 0, circleSegments);
 		}
 		
 		gl.glDisableClientState(GL10.GL_VERTEX_ARRAY);

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/InputMode.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/InputMode.java
@@ -1,0 +1,28 @@
+package com.coboltforge.dontmind.multivnc.ui;
+
+public enum InputMode {
+    DEFAULT("default"),
+    JUMP("jump");
+
+    private final String value;
+
+    InputMode(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static InputMode fromValue(String value) {
+        if (value == null)
+            return DEFAULT;
+
+        for (InputMode mode : values()) {
+            if (mode.value.equals(value))
+                return mode;
+        }
+
+        return DEFAULT;
+    }
+}

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
@@ -10,6 +10,7 @@ import android.view.ScaleGestureDetector;
 import android.view.SoundEffectConstants;
 import android.view.VelocityTracker;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.widget.Toast;
 
@@ -34,6 +35,7 @@ import com.coboltforge.dontmind.multivnc.db.MetaKeyBean;
 public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener implements ScaleGestureDetector.OnScaleGestureListener {
 
     private static final String TAG = "PointerInputHandler";
+    private static final int JUMP_TARGET_RIGHT_CLICK_DELAY_MS = 667;
 
     private final VncCanvas vncCanvas;
     private final ViewGroup mousebuttons;
@@ -63,6 +65,26 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
     float dragX, dragY;
     private boolean dragModeButtonDown = false;
     private boolean dragModeButton2insteadof1 = false;
+    private boolean jumpTargetGestureActive = false;
+    private boolean jumpTargetTapCandidate = false;
+    private boolean jumpTargetLongPressed = false;
+    private boolean jumpTargetDragged = false;
+    private boolean jumpTargetDoubleTapActive = false;
+    private boolean jumpTargetDoubleTapDragging = false;
+    private float jumpTargetStartX, jumpTargetStartY;
+    private final int touchSlopSquared;
+    private final Runnable jumpTargetRightClickRunnable = new Runnable() {
+        @Override
+        public void run() {
+            if (!jumpTargetGestureActive || jumpTargetDragged || jumpTargetDoubleTapActive)
+                return;
+
+            jumpTargetTapCandidate = false;
+            jumpTargetLongPressed = true;
+            vncCanvas.clickMouseButton(VNCConn.MOUSE_BUTTON_RIGHT);
+            vncCanvas.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
+        }
+    };
 
     /*
      * two-finger fling gesture stuff
@@ -81,6 +103,8 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         gestures.setOnDoubleTapListener(this);
         scaleGestures = new ScaleGestureDetector(vncCanvas.getContext(), this);
         scaleGestures.setQuickScaleEnabled(false);
+        int touchSlop = ViewConfiguration.get(vncCanvas.getContext()).getScaledTouchSlop();
+        touchSlopSquared = touchSlop * touchSlop;
 
         Log.d(TAG, "MightyInputHandler " + this +  " created!");
     }
@@ -116,6 +140,77 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
 
     private boolean isJumpInputMode() {
         return inputMode == InputMode.JUMP;
+    }
+
+    private boolean isJumpTargetHit(MotionEvent e) {
+        return isJumpInputMode() && vncCanvas.isJumpTargetHit(e.getX(), e.getY());
+    }
+
+    private boolean shouldHandleJumpTargetTap(MotionEvent e) {
+        return isJumpInputMode() && (jumpTargetTapCandidate || jumpTargetDoubleTapActive);
+    }
+
+    private void beginJumpTargetGesture(MotionEvent e) {
+        jumpTargetGestureActive = true;
+        jumpTargetTapCandidate = true;
+        jumpTargetLongPressed = false;
+        jumpTargetDragged = false;
+        jumpTargetDoubleTapActive = false;
+        jumpTargetDoubleTapDragging = false;
+        jumpTargetStartX = e.getX();
+        jumpTargetStartY = e.getY();
+        vncCanvas.setJumpTargetPressed(true);
+        vncCanvas.handler.removeCallbacks(jumpTargetRightClickRunnable);
+        vncCanvas.handler.postDelayed(jumpTargetRightClickRunnable, JUMP_TARGET_RIGHT_CLICK_DELAY_MS);
+    }
+
+    private void clearJumpTargetGesture() {
+        vncCanvas.handler.removeCallbacks(jumpTargetRightClickRunnable);
+        jumpTargetGestureActive = false;
+        jumpTargetLongPressed = false;
+        jumpTargetDragged = false;
+        jumpTargetDoubleTapActive = false;
+        jumpTargetDoubleTapDragging = false;
+        vncCanvas.setJumpTargetPressed(false);
+    }
+
+    private void releaseJumpTargetPress() {
+        vncCanvas.handler.removeCallbacks(jumpTargetRightClickRunnable);
+        jumpTargetGestureActive = false;
+        jumpTargetLongPressed = false;
+        jumpTargetDragged = false;
+        vncCanvas.setJumpTargetPressed(false);
+    }
+
+    private boolean sendJumpTargetClick(int button) {
+        vncCanvas.clickMouseButton(button);
+        jumpTargetTapCandidate = false;
+        clearJumpTargetGesture();
+        return true;
+    }
+
+    private boolean sendJumpTargetDoubleClick() {
+        vncCanvas.clickMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+        vncCanvas.clickMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+        jumpTargetTapCandidate = false;
+        clearJumpTargetGesture();
+        return true;
+    }
+
+    private boolean moveJumpTargetDrag(MotionEvent e) {
+        vncCanvas.moveMouseForJumpTargetCenter(e.getX(), e.getY());
+        return true;
+    }
+
+    private boolean moveJumpTargetMarqueeDrag(MotionEvent e) {
+        vncCanvas.dragMouseButtonForJumpTargetCenter(VNCConn.MOUSE_BUTTON_LEFT, e.getX(), e.getY());
+        return true;
+    }
+
+    private boolean isPastJumpTargetDragSlop(MotionEvent e) {
+        float dx = e.getX() - jumpTargetStartX;
+        float dy = e.getY() - jumpTargetStartY;
+        return dx * dx + dy * dy > touchSlopSquared;
     }
 
     protected boolean isTouchEvent(MotionEvent event) {
@@ -230,6 +325,11 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
 
         if(Utils.DEBUG()) Log.d(TAG, "Input: long press");
 
+        if (jumpTargetGestureActive) {
+            if(Utils.DEBUG()) Log.d(TAG, "Input: Jump-style target long press");
+            return;
+        }
+
         if (isJumpInputMode())
             return;
 
@@ -329,6 +429,19 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         }
         else
         {
+            if (jumpTargetGestureActive) {
+                if (isPastJumpTargetDragSlop(e2)) {
+                    jumpTargetTapCandidate = false;
+                    jumpTargetDragged = true;
+                    if (jumpTargetDoubleTapActive) {
+                        jumpTargetDoubleTapDragging = true;
+                        return moveJumpTargetMarqueeDrag(e2);
+                    }
+                    return moveJumpTargetDrag(e2);
+                }
+                return true;
+            }
+
             if (isJumpInputMode()) {
                 if(Utils.DEBUG()) Log.d(TAG, "Input: Jump-style single touch pan");
                 return vncCanvas.pan((int) distanceX, (int) distanceY);
@@ -364,6 +477,56 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
             vncCanvas.processPointerEvent(e2, false);
         }
         return false;
+    }
+
+    private boolean handleJumpTargetTouchEvent(MotionEvent e) {
+        if (!isJumpInputMode())
+            return false;
+
+        switch (e.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN:
+                jumpTargetTapCandidate = false;
+                if (isJumpTargetHit(e)) {
+                    beginJumpTargetGesture(e);
+                    return false;
+                }
+                clearJumpTargetGesture();
+                return false;
+
+            case MotionEvent.ACTION_CANCEL:
+                jumpTargetTapCandidate = false;
+                if (jumpTargetDoubleTapDragging)
+                    vncCanvas.releaseMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+                clearJumpTargetGesture();
+                return true;
+
+            case MotionEvent.ACTION_UP:
+                if (jumpTargetGestureActive) {
+                    if (jumpTargetDoubleTapDragging)
+                        vncCanvas.releaseMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+                    if (jumpTargetLongPressed && !jumpTargetDragged) {
+                        clearJumpTargetGesture();
+                    }
+                    else if (jumpTargetDragged || jumpTargetDoubleTapDragging)
+                        clearJumpTargetGesture();
+                    else
+                        releaseJumpTargetPress();
+                    return false;
+                }
+                return false;
+
+            default:
+                if (jumpTargetGestureActive && isPastJumpTargetDragSlop(e)) {
+                    jumpTargetTapCandidate = false;
+                    jumpTargetDragged = true;
+                    if (jumpTargetDoubleTapActive) {
+                        jumpTargetDoubleTapDragging = true;
+                        return moveJumpTargetMarqueeDrag(e);
+                    }
+                    return moveJumpTargetDrag(e);
+                }
+                return false;
+        }
     }
 
 
@@ -438,6 +601,10 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
 
         if(Utils.DEBUG())
             Log.d(TAG, "Input: touch normal: x:" + e.getX() + " y:" + e.getY() + " action:" + e.getAction());
+
+        boolean handledByJumpTarget = handleJumpTargetTouchEvent(e);
+        if (handledByJumpTarget)
+            return true;
 
         scaleGestures.onTouchEvent(e);
         return gestures.onTouchEvent(e);
@@ -541,6 +708,9 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         if (!isTouchEvent(e))
             return false;
 
+        if (shouldHandleJumpTargetTap(e))
+            return sendJumpTargetClick(VNCConn.MOUSE_BUTTON_LEFT);
+
         // disable if virtual mouse buttons are in use
         if(mousebuttons.getVisibility()== View.VISIBLE)
             return false;
@@ -564,6 +734,12 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         if (!isTouchEvent(e))
             return false;
 
+        if (shouldHandleJumpTargetTap(e)) {
+            jumpTargetDoubleTapActive = true;
+            jumpTargetDoubleTapDragging = false;
+            return true;
+        }
+
         // disable if virtual mouse buttons are in use
         if(mousebuttons.getVisibility()== View.VISIBLE)
             return false;
@@ -577,6 +753,46 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         vncCanvas.processPointerEvent(e, true, true);
         e.setAction(MotionEvent.ACTION_UP);
         return vncCanvas.processPointerEvent(e, false, true);
+    }
+
+    @Override
+    public boolean onDoubleTapEvent(MotionEvent e) {
+        if (!shouldHandleJumpTargetTap(e))
+            return false;
+
+        switch (e.getActionMasked()) {
+            case MotionEvent.ACTION_DOWN:
+                jumpTargetDoubleTapActive = true;
+                jumpTargetDoubleTapDragging = false;
+                return true;
+
+            case MotionEvent.ACTION_MOVE:
+                if (isPastJumpTargetDragSlop(e)) {
+                    jumpTargetTapCandidate = false;
+                    jumpTargetDragged = true;
+                    jumpTargetDoubleTapActive = true;
+                    jumpTargetDoubleTapDragging = true;
+                    return moveJumpTargetMarqueeDrag(e);
+                }
+                return true;
+
+            case MotionEvent.ACTION_UP:
+                if (jumpTargetDoubleTapDragging) {
+                    vncCanvas.releaseMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+                    clearJumpTargetGesture();
+                    return true;
+                }
+                return sendJumpTargetDoubleClick();
+
+            case MotionEvent.ACTION_CANCEL:
+                if (jumpTargetDoubleTapDragging)
+                    vncCanvas.releaseMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+                clearJumpTargetGesture();
+                return true;
+
+            default:
+                return true;
+        }
     }
 
 

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
@@ -112,6 +112,10 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         return inputMode;
     }
 
+    private boolean isJumpInputMode() {
+        return inputMode == InputMode.JUMP;
+    }
+
     protected boolean isTouchEvent(MotionEvent event) {
         return event.getSource() == InputDevice.SOURCE_TOUCHSCREEN ||
                 event.getSource() == InputDevice.SOURCE_TOUCHPAD;
@@ -224,6 +228,9 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
 
         if(Utils.DEBUG()) Log.d(TAG, "Input: long press");
 
+        if (isJumpInputMode())
+            return;
+
         dragMode = true;
         dragX = e.getX();
         dragY = e.getY();
@@ -320,6 +327,11 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         }
         else
         {
+            if (isJumpInputMode()) {
+                if(Utils.DEBUG()) Log.d(TAG, "Input: Jump-style single touch pan");
+                return vncCanvas.pan((int) distanceX, (int) distanceY);
+            }
+
             // compute the relative movement offset on the remote screen.
             float deltaX = -distanceX;
             float deltaY = -distanceY;

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
@@ -35,6 +35,8 @@ import com.coboltforge.dontmind.multivnc.db.MetaKeyBean;
 public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener implements ScaleGestureDetector.OnScaleGestureListener {
 
     private static final String TAG = "PointerInputHandler";
+    private static final int JUMP_TAP_MOVE_ANIMATION_DURATION_MS = 50;
+    private static final int JUMP_TAP_MOVE_ANIMATION_STEPS = 5;
     private static final int JUMP_TARGET_RIGHT_CLICK_DELAY_MS = 667;
 
     private final VncCanvas vncCanvas;
@@ -140,6 +142,38 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
 
     private boolean isJumpInputMode() {
         return inputMode == InputMode.JUMP;
+    }
+
+    private boolean movePointerToTapAndClick(MotionEvent e) {
+        int startX = vncCanvas.mouseX;
+        int startY = vncCanvas.mouseY;
+        vncCanvas.changeTouchCoordinatesToFullFrame(e);
+        animatePointerToTapAndClick(startX, startY, (int)e.getX(), (int)e.getY());
+        return true;
+    }
+
+    private void animatePointerToTapAndClick(final int startX, final int startY, final int endX, final int endY) {
+        final int stepDelayMs = JUMP_TAP_MOVE_ANIMATION_DURATION_MS / JUMP_TAP_MOVE_ANIMATION_STEPS;
+        vncCanvas.handler.postDelayed(new Runnable() {
+            private int step = 0;
+
+            @Override
+            public void run() {
+                step++;
+                float progress = (float)step / JUMP_TAP_MOVE_ANIMATION_STEPS;
+                int x = (int)(startX + (endX - startX) * progress);
+                int y = (int)(startY + (endY - startY) * progress);
+                vncCanvas.warpMouseAndRefreshRemoteCursor(x, y);
+
+                if (step < JUMP_TAP_MOVE_ANIMATION_STEPS) {
+                    vncCanvas.handler.postDelayed(this, stepDelayMs);
+                }
+                else {
+                    vncCanvas.clickMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+                    vncCanvas.refreshRemoteCursor();
+                }
+            }
+        }, stepDelayMs);
     }
 
     private boolean isJumpTargetHit(MotionEvent e) {
@@ -495,20 +529,28 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
 
             case MotionEvent.ACTION_CANCEL:
                 jumpTargetTapCandidate = false;
-                if (jumpTargetDoubleTapDragging)
+                if (jumpTargetDoubleTapDragging) {
                     vncCanvas.releaseMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+                    vncCanvas.refreshRemoteCursor();
+                }
+                else if (jumpTargetDragged) {
+                    vncCanvas.refreshRemoteCursor();
+                }
                 clearJumpTargetGesture();
                 return true;
 
             case MotionEvent.ACTION_UP:
                 if (jumpTargetGestureActive) {
-                    if (jumpTargetDoubleTapDragging)
+                    if (jumpTargetDoubleTapDragging) {
                         vncCanvas.releaseMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
-                    if (jumpTargetLongPressed && !jumpTargetDragged) {
+                        vncCanvas.refreshRemoteCursor();
+                    }
+                    if (jumpTargetLongPressed && !jumpTargetDragged)
+                        clearJumpTargetGesture();
+                    else if (jumpTargetDragged || jumpTargetDoubleTapDragging) {
+                        vncCanvas.refreshRemoteCursor();
                         clearJumpTargetGesture();
                     }
-                    else if (jumpTargetDragged || jumpTargetDoubleTapDragging)
-                        clearJumpTargetGesture();
                     else
                         releaseJumpTargetPress();
                     return false;
@@ -711,6 +753,9 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         if (shouldHandleJumpTargetTap(e))
             return sendJumpTargetClick(VNCConn.MOUSE_BUTTON_LEFT);
 
+        if (isJumpInputMode())
+            return movePointerToTapAndClick(e);
+
         // disable if virtual mouse buttons are in use
         if(mousebuttons.getVisibility()== View.VISIBLE)
             return false;
@@ -739,6 +784,9 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
             jumpTargetDoubleTapDragging = false;
             return true;
         }
+
+        if (isJumpInputMode())
+            return movePointerToTapAndClick(e);
 
         // disable if virtual mouse buttons are in use
         if(mousebuttons.getVisibility()== View.VISIBLE)
@@ -779,14 +827,17 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
             case MotionEvent.ACTION_UP:
                 if (jumpTargetDoubleTapDragging) {
                     vncCanvas.releaseMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+                    vncCanvas.refreshRemoteCursor();
                     clearJumpTargetGesture();
                     return true;
                 }
                 return sendJumpTargetDoubleClick();
 
             case MotionEvent.ACTION_CANCEL:
-                if (jumpTargetDoubleTapDragging)
+                if (jumpTargetDoubleTapDragging) {
                     vncCanvas.releaseMouseButton(VNCConn.MOUSE_BUTTON_LEFT);
+                    vncCanvas.refreshRemoteCursor();
+                }
                 clearJumpTargetGesture();
                 return true;
 

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
@@ -106,6 +106,8 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
             this.inputMode = InputMode.DEFAULT;
         else
             this.inputMode = inputMode;
+
+        vncCanvas.reDraw();
     }
 
     public InputMode getInputMode() {

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
@@ -287,7 +287,7 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
     public boolean onScaleBegin(ScaleGestureDetector detector) {
         xInitialFocus = detector.getFocusX();
         yInitialFocus = detector.getFocusY();
-        inScaling = false;
+        inScaling = isJumpInputMode();
         //Log.i(TAG,"scale begin ("+xInitialFocus+","+yInitialFocus+")");
         return true;
     }
@@ -391,6 +391,9 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         if (e2.getPointerCount() > 1)
         {
             if(Utils.DEBUG()) Log.d(TAG, "Input: scroll multitouch");
+
+            if (isJumpInputMode() && e2.getPointerCount() == 2 && scaleGestures.isInProgress())
+                return false;
 
             if (inScaling)
                 return false;

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/PointerInputHandler.java
@@ -38,6 +38,7 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
     private final VncCanvas vncCanvas;
     private final ViewGroup mousebuttons;
     private final Toast notificationToast;
+    private InputMode inputMode = InputMode.DEFAULT;
     protected GestureDetector gestures;
     protected ScaleGestureDetector scaleGestures;
 
@@ -100,6 +101,16 @@ public class PointerInputHandler extends GestureDetector.SimpleOnGestureListener
         Log.d(TAG, "MightyInputHandler " + this +  " shutdown!");
     }
 
+    public void setInputMode(InputMode inputMode) {
+        if (inputMode == null)
+            this.inputMode = InputMode.DEFAULT;
+        else
+            this.inputMode = inputMode;
+    }
+
+    public InputMode getInputMode() {
+        return inputMode;
+    }
 
     protected boolean isTouchEvent(MotionEvent event) {
         return event.getSource() == InputDevice.SOURCE_TOUCHSCREEN ||

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvas.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvas.java
@@ -77,6 +77,7 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 	private final static float JUMP_TARGET_RADIUS_DP = 30.0f;
 	private final static float JUMP_TARGET_CURSOR_HEIGHT_DP = 24.0f;
 	private final static float JUMP_TARGET_CURSOR_GAP_DP = 28.0f;
+	private final static int REMOTE_CURSOR_REFRESH_RADIUS = 64;
 
 	ZoomScaling scaling;
 
@@ -184,6 +185,7 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 		int pointerY = (int)(absoluteYPosition +
 				(targetCenterY - getJumpTargetCursorHeightPx() - getJumpTargetCursorGapPx() - getJumpTargetRadiusPx()) / scale);
 		processMouseEvent(VNCConn.MOUSE_BUTTON_NONE, false, pointerX, pointerY);
+		refreshRemoteCursor();
 	}
 
 	void dragMouseButtonForJumpTargetCenter(int button, float targetCenterX, float targetCenterY) {
@@ -192,6 +194,7 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 		int pointerY = (int)(absoluteYPosition +
 				(targetCenterY - getJumpTargetCursorHeightPx() - getJumpTargetCursorGapPx() - getJumpTargetRadiusPx()) / scale);
 		processMouseEvent(button, true, pointerX, pointerY);
+		refreshRemoteCursor();
 	}
 
 
@@ -417,6 +420,31 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 		reDraw(); // update local pointer position
 		panToMouse();
 		vncConn.sendPointerEvent(x, y, 0, VNCConn.MOUSE_BUTTON_NONE);
+	}
+
+	public void warpMouseAndRefreshRemoteCursor(int x, int y) {
+		int oldX = mouseX;
+		int oldY = mouseY;
+		warpMouse(x, y);
+		requestRemoteCursorRefresh(oldX, oldY);
+		requestRemoteCursorRefresh(mouseX, mouseY);
+	}
+
+	public void refreshRemoteCursor() {
+		requestRemoteCursorRefresh(mouseX, mouseY);
+	}
+
+	private void requestRemoteCursorRefresh(int centerX, int centerY) {
+		if (vncConn == null)
+			return;
+
+		int size = REMOTE_CURSOR_REFRESH_RADIUS * 2;
+		vncConn.requestFramebufferUpdate(
+				centerX - REMOTE_CURSOR_REFRESH_RADIUS,
+				centerY - REMOTE_CURSOR_REFRESH_RADIUS,
+				size,
+				size,
+				false);
 	}
 
 

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvas.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvas.java
@@ -73,6 +73,10 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
     }
 
 	private final static String TAG = "VncCanvas";
+	private final static float GL_FIXED_ONE = 65536.0f;
+	private final static float JUMP_TARGET_RADIUS_DP = 30.0f;
+	private final static float JUMP_TARGET_CURSOR_HEIGHT_DP = 24.0f;
+	private final static float JUMP_TARGET_CURSOR_GAP_DP = 28.0f;
 
 	ZoomScaling scaling;
 
@@ -121,6 +125,49 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 	 * full-frame coordinates
 	 */
 	int absoluteXPosition = 0, absoluteYPosition = 0;
+
+	private float getJumpTargetRadiusPx() {
+		return JUMP_TARGET_RADIUS_DP * getResources().getDisplayMetrics().density;
+	}
+
+	private float getJumpTargetCursorGapPx() {
+		return JUMP_TARGET_CURSOR_GAP_DP * getResources().getDisplayMetrics().density;
+	}
+
+	private float getJumpTargetCursorHeightPx() {
+		return JUMP_TARGET_CURSOR_HEIGHT_DP * getResources().getDisplayMetrics().density;
+	}
+
+	private boolean shouldShowJumpTarget() {
+		return inputHandler != null && inputHandler.getInputMode() == InputMode.JUMP;
+	}
+
+	private float getMouseXOnScreen() {
+		return getScale() * (mouseX - absoluteXPosition);
+	}
+
+	private float getMouseYOnScreen() {
+		return getScale() * (mouseY - absoluteYPosition);
+	}
+
+	private float getJumpTargetCenterX() {
+		return getMouseXOnScreen();
+	}
+
+	private float getJumpTargetCenterY() {
+		float radius = getJumpTargetRadiusPx();
+		return getMouseYOnScreen() + getJumpTargetCursorHeightPx() + getJumpTargetCursorGapPx() + radius;
+	}
+
+	boolean isJumpTargetHit(float x, float y) {
+		if (!shouldShowJumpTarget())
+			return false;
+
+		float dx = x - getJumpTargetCenterX();
+		float dy = y - getJumpTargetCenterY();
+		float radius = getJumpTargetRadiusPx();
+		return dx * dx + dy * dy <= radius * radius;
+	}
 
 
 	/*
@@ -256,8 +303,8 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 				 */
 				if(doPointerHighLight) {
 					gl.glEnable(GL10.GL_BLEND);
-					int mouseXonScreen = (int)(getScale()*(mouseX-absoluteXPosition));
-					int mouseYonScreen = (int)(getScale()*(mouseY-absoluteYPosition));
+					int mouseXonScreen = (int)getMouseXOnScreen();
+					int mouseYonScreen = (int)getMouseYOnScreen();
 
 					gl.glLoadIdentity();                 // Reset model-view matrix
 					gl.glTranslatex( mouseXonScreen, mouseYonScreen, 0);
@@ -273,6 +320,19 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 					gl.glScalef(0.99f, 0.99f, 0.0f);
 					circle.draw(gl);
 
+					gl.glDisable(GL10.GL_BLEND);
+				}
+
+				if(shouldShowJumpTarget()) {
+					gl.glEnable(GL10.GL_BLEND);
+					gl.glLoadIdentity();
+					gl.glTranslatex((int)getJumpTargetCenterX(), (int)getJumpTargetCenterY(), 0);
+					float radiusScale = getJumpTargetRadiusPx() / GL_FIXED_ONE;
+					gl.glScalef(radiusScale, radiusScale, 1.0f);
+					gl.glLineWidth(2.0f);
+					gl.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+					circle.drawOutline(gl);
+					gl.glLineWidth(1.0f);
 					gl.glDisable(GL10.GL_BLEND);
 				}
 
@@ -565,7 +625,7 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 
 	public void reDraw() {
 
-		if (repaintsEnabled && vncConn.rfbClient != 0) {
+		if (repaintsEnabled && vncConn != null && vncConn.rfbClient != 0) {
 			// request a redraw from GL thread
 			requestRender();
 		}

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvas.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvas.java
@@ -99,6 +99,7 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 	private PointerInputHandler inputHandler;
 
 	private VNCGLRenderer glRenderer;
+	private boolean jumpTargetPressed = false;
 
 	//whether to do pointer highlighting
 	boolean doPointerHighLight = true;
@@ -167,6 +168,30 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 		float dy = y - getJumpTargetCenterY();
 		float radius = getJumpTargetRadiusPx();
 		return dx * dx + dy * dy <= radius * radius;
+	}
+
+	void setJumpTargetPressed(boolean pressed) {
+		if (jumpTargetPressed == pressed)
+			return;
+
+		jumpTargetPressed = pressed;
+		reDraw();
+	}
+
+	void moveMouseForJumpTargetCenter(float targetCenterX, float targetCenterY) {
+		float scale = getScale();
+		int pointerX = (int)(absoluteXPosition + targetCenterX / scale);
+		int pointerY = (int)(absoluteYPosition +
+				(targetCenterY - getJumpTargetCursorHeightPx() - getJumpTargetCursorGapPx() - getJumpTargetRadiusPx()) / scale);
+		processMouseEvent(VNCConn.MOUSE_BUTTON_NONE, false, pointerX, pointerY);
+	}
+
+	void dragMouseButtonForJumpTargetCenter(int button, float targetCenterX, float targetCenterY) {
+		float scale = getScale();
+		int pointerX = (int)(absoluteXPosition + targetCenterX / scale);
+		int pointerY = (int)(absoluteYPosition +
+				(targetCenterY - getJumpTargetCursorHeightPx() - getJumpTargetCursorGapPx() - getJumpTargetRadiusPx()) / scale);
+		processMouseEvent(button, true, pointerX, pointerY);
 	}
 
 
@@ -329,6 +354,10 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 					gl.glTranslatex((int)getJumpTargetCenterX(), (int)getJumpTargetCenterY(), 0);
 					float radiusScale = getJumpTargetRadiusPx() / GL_FIXED_ONE;
 					gl.glScalef(radiusScale, radiusScale, 1.0f);
+					if(jumpTargetPressed) {
+						gl.glColor4f(0.3f, 0.55f, 1.0f, 0.35f);
+						circle.draw(gl);
+					}
 					gl.glLineWidth(2.0f);
 					gl.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
 					circle.drawOutline(gl);
@@ -590,6 +619,7 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 
 
 			if (sX != 0.0 || sY != 0.0) {
+				reDraw();
 				return true;
 			}
 		} catch (Exception ignored) {
@@ -767,6 +797,19 @@ public class VncCanvas extends GLSurfaceView implements VNCConn.OnFramebufferEve
 
 		} catch (NullPointerException ignored) {
 		}
+	}
+
+	public void clickMouseButton(int button) {
+		processMouseEvent(button, true, mouseX, mouseY);
+		processMouseEvent(button, false, mouseX, mouseY);
+	}
+
+	public void holdMouseButton(int button) {
+		processMouseEvent(button, true, mouseX, mouseY);
+	}
+
+	public void releaseMouseButton(int button) {
+		processMouseEvent(button, false, mouseX, mouseY);
 	}
 
 

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvasActivity.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvasActivity.java
@@ -87,6 +87,7 @@ public class VncCanvasActivity extends AppCompatActivity implements PopupMenu.On
 	ZoomControls zoomer;
 	TextView zoomLevel;
 	PointerInputHandler inputHandler;
+	InputMode inputMode = InputMode.DEFAULT;
 
 	ViewGroup mousebuttons;
 	TouchPointView touchpoints;
@@ -553,6 +554,15 @@ public class VncCanvasActivity extends AppCompatActivity implements PopupMenu.On
 				ed.putBoolean(Constants.PREFS_KEY_MOUSEBUTTONS, true);
 			}
 			ed.commit();
+			return true;
+
+		case R.id.itemToggleJumpInputMode:
+			if(inputMode == InputMode.JUMP)
+				inputMode = InputMode.DEFAULT;
+			else
+				inputMode = InputMode.JUMP;
+
+			inputHandler.setInputMode(inputMode);
 			return true;
 
 		case R.id.itemTogglePointerHighlight:

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvasActivity.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/VncCanvasActivity.java
@@ -239,6 +239,8 @@ public class VncCanvasActivity extends AppCompatActivity implements PopupMenu.On
 			connection.parseHostPort(connection.address);
 		}
 
+		inputMode = InputMode.fromValue(connection.inputMode);
+		inputHandler.setInputMode(inputMode);
 
 		/*
 		 * Setup canvas and conn.

--- a/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/ZoomScaling.java
+++ b/android/app/src/main/java/com/coboltforge/dontmind/multivnc/ui/ZoomScaling.java
@@ -27,7 +27,7 @@ class ZoomScaling {
 	/**
 	 * Updates scale to given value.
 	 */
-	private void updateScale(float newScale) {
+	private float updateScale(float newScale) {
 		float oldScale = currentScale;
 
 		//Clamp scale to min/max limits
@@ -42,8 +42,10 @@ class ZoomScaling {
 		activity.vncCanvas.pan(0, 0);
 
 		//Notify user
-		if (newScale != oldScale)
+		if (currentScale != oldScale)
 			activity.showZoomLevel();
+
+		return currentScale / oldScale;
 	}
 	
 	void zoomIn() {
@@ -59,11 +61,13 @@ class ZoomScaling {
 	}
 
 	void adjust(float scaleFactor, float fx, float fy) {
-		updateScale(currentScale * scaleFactor);
+		float actualScaleFactor = updateScale(currentScale * scaleFactor);
+		if (actualScaleFactor == 1.0f)
+			return;
 
 		//Keep the focal point fixed.
-		int focusShiftX = (int) (fx * (1 - scaleFactor));
-		int focusShiftY = (int) (fy * (1 - scaleFactor));
+		int focusShiftX = (int) (fx * (1 - actualScaleFactor));
+		int focusShiftY = (int) (fy * (1 - actualScaleFactor));
 		activity.vncCanvas.pan(-focusShiftX, -focusShiftY);
 	}
 

--- a/android/app/src/main/res/layout/connection_edit_fragment.xml
+++ b/android/app/src/main/res/layout/connection_edit_fragment.xml
@@ -137,6 +137,22 @@
             android:prompt="@string/colormode_caption" />
     </TableRow>
 
+    <TableRow
+        android:id="@+id/input_mode_row"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_gravity="right|center_vertical"
+            android:paddingRight="10dip"
+            android:text="@string/input_mode_caption"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/jump_mode_switch"
+            android:layout_weight="1"
+            android:text="" />
+    </TableRow>
+
     <TableRow>
 
         <TextView

--- a/android/app/src/main/res/menu/vnccanvasactivitymenu.xml
+++ b/android/app/src/main/res/menu/vnccanvasactivitymenu.xml
@@ -24,6 +24,11 @@
     </item>
 
     <item
+        android:id="@+id/itemToggleJumpInputMode"
+        android:title="@string/toggle_jump_input_mode">
+    </item>
+
+    <item
         android:id="@+id/itemTogglePointerHighlight"
         android:title="@string/toggle_pointer_highlight">
     </item>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
 <string name="disconnect">Disconnect</string>
 <string name="toggle_framebuffer_update">Toggle View</string>
 <string name="toggle_mouse_buttons">Toggle Mouse Buttons</string>
+<string name="toggle_jump_input_mode">Toggle Jump-style Touch Mode</string>
 <string name="toggle_pointer_highlight">Toggle Pointer Highlighting</string>
 <string name="toggle_keyboard">Toggle Keyboard</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
 <string name="toggle_framebuffer_update">Toggle View</string>
 <string name="toggle_mouse_buttons">Toggle Mouse Buttons</string>
 <string name="toggle_jump_input_mode">Toggle Jump-style Touch Mode</string>
+<string name="input_mode_caption">Jump-style Touch Mode</string>
 <string name="toggle_pointer_highlight">Toggle Pointer Highlighting</string>
 <string name="toggle_keyboard">Toggle Keyboard</string>
 


### PR DESCRIPTION
## Summary

Adds a selectable "Jump desktop"-style touch input mode for Android VNC sessions.

This mode preserves the existing default touch behavior while adding:
- one-finger viewport panning instead of remote pointer dragging
- outside-target tap-to-move-and-click behavior
- a cursor-adjacent circular touch target for left click, double click, right click, drag-to-move, and marquee selection
- active-session mode toggling from the canvas menu
- per-connection default mode selection

## Details

The implementation introduces an `InputMode` model with safe default fallback for null or unknown values. Jump-style behavior is gated behind `InputMode.JUMP`; default input mode behavior remains unchanged.

The Jump target is drawn in the existing GL overlay path so it remains stable in screen space across zoom levels. Target interactions are handled in `PointerInputHandler` and use the existing VNC pointer event paths.

To improve remote cursor visibility after Jump-style pointer movement, the Android client now queues framebuffer refresh requests around cursor movement and release points.

## User-Facing Behavior

In Jump-style mode:
- dragging outside the target pans the viewport
- tapping outside the target moves the remote pointer to the tap location and left-clicks
- tapping the target left-clicks at the cursor
- double-tapping the target double-clicks
- holding the target right-clicks after a short delay
- dragging from the target moves the remote pointer while keeping the target under the finger
- double-tap-and-drag from the target performs marquee selection / select-and-drag behavior

## Verification

Manual verification performed during development:
- default mode remains available and unchanged
- active-session Jump toggle works
- per-connection Jump mode persists and applies on connection open
- Jump target renders below the cursor as a white outline with pressed feedback
- target size remains stable across zoom levels
- target click, double-click, right-click, drag, and marquee behaviors work
- outside-target tap-to-click moves the pointer and requests cursor-area refreshes
- pinch zoom at zoom limits no longer pans the viewport

Automated/build checks were not run in this environment.